### PR TITLE
메뉴 기능 구현 + 애니메이션 로직 수정 + 기타 변경

### DIFF
--- a/constants/child.js
+++ b/constants/child.js
@@ -1,5 +1,4 @@
 export const DX_OFFSET = 35;
-export const [LEFT, RIGHT] = ['left', 'right'];
 export const BOUNCE_TIME = 300;
 export const FEED_TIME = 300;
 export const MOVE_TIME = 500;

--- a/constants/egg.js
+++ b/constants/egg.js
@@ -1,6 +1,3 @@
-export const STANDING = 'standing';
-export const SHAKED = 'shaked';
-export const BIRTH = 'birth';
 export const DX_OFFSET = 15;
 export const STANDUP_TIME = 500;
 export const SHAKED_TIME = 300;

--- a/constants/gameState.js
+++ b/constants/gameState.js
@@ -6,4 +6,4 @@ export const [MENU, IDLING, EATING, PLAYING] = [
   'EATING',
   'PLAYING',
 ];
-export const TICK_SECONDS = 3000;
+export const TICK_SECONDS = 5000;

--- a/index.html
+++ b/index.html
@@ -5,8 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./style.css" />
-    <script defer type="module" src="./init.js"></script>
+    <link
+      href="https://fonts.googleapis.com/css?family=VT323"
+      rel="stylesheet" />
     <title>Document</title>
+    <script defer type="module" src="./init.js"></script>
   </head>
   <body>
     <div class="tamagotchi-container">
@@ -18,6 +21,12 @@
         <button class="btn btn--3"></button>
       </div>
       <div class="modal"><span>Press Any Button!</span></div>
+      <div class="menu hidden">
+        <div class="menu-item">FEED</div>
+        <div class="menu-item">PLAY</div>
+        <div class="menu-item">STATE</div>
+        <div class="menu-item">SLEEP</div>
+      </div>
     </div>
   </body>
 </html>

--- a/init.js
+++ b/init.js
@@ -1,12 +1,12 @@
 import gameState from './models/GameState.js';
 import buttonState from './models/ButtonState.js';
-import Frame from './views/Frame.js';
+import frame from './views/Frame.js';
 
-import { drawFrame, handleStateOverTime } from './controllers/controller.js';
+import { handleStatesOverTime } from './controllers/controller.js';
 
 function init() {
-  drawFrame(Frame);
-  handleStateOverTime(gameState, buttonState);
+  frame.draw();
+  handleStatesOverTime(gameState, buttonState);
 }
 
 init();

--- a/models/ButtonState.js
+++ b/models/ButtonState.js
@@ -7,6 +7,9 @@ class ButtonState {
     this.leftBtn = document.querySelector('.btn--1');
     this.middleBtn = document.querySelector('.btn--2');
     this.rightBtn = document.querySelector('.btn--3');
+
+    this.addListeners = this.addListeners.bind(this);
+    this.removeListeners = this.removeListeners.bind(this);
   }
 
   get state() {
@@ -17,7 +20,7 @@ class ButtonState {
     this._state = state;
   }
 
-  addAllListeners({ leftCallback, middleCallback, rightCallback }) {
+  addListeners({ leftCallback, middleCallback, rightCallback }) {
     this.leftCallback = leftCallback;
     this.middleCallback = middleCallback;
     this.rightCallback = rightCallback;
@@ -27,7 +30,7 @@ class ButtonState {
     this.rightBtn.addEventListener('click', this.rightCallback);
   }
 
-  removeAllListeners() {
+  removeListeners() {
     this.leftBtn.removeEventListener('click', this.leftCallback);
     this.middleBtn.removeEventListener('click', this.middleCallback);
     this.rightBtn.removeEventListener('click', this.rightCallback);

--- a/models/GameState.js
+++ b/models/GameState.js
@@ -1,41 +1,61 @@
-import { INIT, GROWTH, IDLING } from '../constants/gameState.js';
+import { INIT, GROWTH, IDLING, MENU } from '../constants/gameState.js';
 
 class GameState {
   constructor() {
-    this.clock = 0;
-    this.nextTimeToTick = Date.now();
-    this.currentState = INIT;
+    this.state = INIT;
     this.growth = INIT;
     this.fun = -1;
     this.hungry = -1;
     this.birthCount = -1;
+
+    this.setStatesByTime = this.setStatesByTime.bind(this);
     this.startGame = this.startGame.bind(this);
     this.hatchEgg = this.hatchEgg.bind(this);
-    this.modal = document.querySelector('.modal');
+    this.setMenuState = this.setMenuState.bind(this);
+    this.cancelMenuState = this.cancelMenuState.bind(this);
   }
 
-  tick() {
-    this.clock++;
+  setStatesByTime() {
+    if (
+      (this.growth === GROWTH[1] || this.growth === GROWTH[2]) &&
+      this.state !== MENU
+    ) {
+      if (this.fun) {
+        this.fun -= 1;
+      }
+
+      if (this.hungry < 10) {
+        this.hungry += 1;
+      }
+    }
   }
 
   startGame() {
-    this.currentState = GROWTH[0];
+    this.state = GROWTH[0];
     this.growth = GROWTH[0];
     this.birthCount = 5;
   }
 
-  hatchEgg(shake, breakEgg) {
-    if (!this.birthCount) {
-      breakEgg();
-      this.modal.classList.add('hidden');
+  async hatchEgg(shake) {
+    if (this.birthCount <= 0) {
       this.growth = GROWTH[1];
-      this.currentState = IDLING;
+      this.fun = 10;
+      this.hungry = 0;
+      this.state = IDLING;
     }
 
     if (this.birthCount) {
-      shake();
+      await shake();
       this.birthCount--;
     }
+  }
+
+  setMenuState() {
+    this.state = MENU;
+  }
+
+  cancelMenuState() {
+    this.state = IDLING;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -76,6 +76,33 @@ body {
   box-shadow: 0 5px 5px rgba(0, 0, 0, 0.3);
 }
 
+/* MENU */
+
+.menu {
+  display: flex;
+  flex-direction: column;
+  gap: 50px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.menu-item {
+  width: 150px;
+  font-size: 40px;
+  font-family: 'VT323';
+}
+
+.focused::before {
+  content: '>';
+  width: 50px;
+  height: 50px;
+}
+
 /* ETC */
 
 .hidden {

--- a/views/Animatable.js
+++ b/views/Animatable.js
@@ -1,24 +1,23 @@
 class Animatable {
   constructor() {
     this.context = document.querySelector('#tablet').getContext('2d');
+    this.isCanceled = false;
+    this.timer = null;
     this.image = new Image();
     this.pending = [];
   }
 
-  animate(draw, ms, nextAnimation = null) {
+  animate(draw, ms) {
     return new Promise((resolve) => {
       const animation = async () => {
         this.clear();
+        if (this.isCanceled) return;
+
         const isComplete = draw(resolve);
 
         if (!isComplete) {
           await this.delay(ms);
           animation();
-        }
-
-        if (isComplete && nextAnimation) {
-          await this.delay(ms);
-          nextAnimation();
         }
       };
 
@@ -26,7 +25,11 @@ class Animatable {
     });
   }
 
-  async handleEvent(idle) {
+  cancelAnimation(isCanceled) {
+    this.isCanceled = isCanceled;
+  }
+
+  async handlePendingEvent(idle) {
     const event = this.pending.shift();
     if (typeof event !== 'function') return;
 

--- a/views/Egg.js
+++ b/views/Egg.js
@@ -1,8 +1,5 @@
 import Animatable from './Animatable.js';
 import {
-  STANDING,
-  SHAKED,
-  BIRTH,
   DX_OFFSET,
   STANDUP_TIME,
   SHAKED_TIME,
@@ -17,28 +14,14 @@ class Egg extends Animatable {
     this.frameWidth = 180;
     this.dX = 110;
     this.dY = 120;
-  }
-
-  drawEgg(state, nextDraw = null) {
-    this.image.removeEventListener('load', this.callback);
     this.image.src = EGG_PATH;
 
-    switch (state) {
-      case STANDING:
-        this.callback = this._standUpEgg.bind(this);
-        break;
-      case SHAKED:
-        this.callback = this._shakeEgg.bind(this);
-        break;
-      case BIRTH:
-        this.callback = this._breakEgg.bind(this, nextDraw);
-        break;
-    }
-
-    this.image.addEventListener('load', this.callback);
+    this.drawStandingEgg = this.drawStandingEgg.bind(this);
+    this.drawShakedEgg = this.drawShakedEgg.bind(this);
+    this.drawBreakingEgg = this.drawBreakingEgg.bind(this);
   }
 
-  _standUpEgg() {
+  async drawStandingEgg() {
     const lastFrame = 3;
     let currentFrame = 0;
 
@@ -57,15 +40,13 @@ class Egg extends Animatable {
       currentFrame++;
 
       if (lastFrame === currentFrame) {
-        clearTimeout(this.timer);
         resolve();
-
         return true;
       }
     }, STANDUP_TIME);
   }
 
-  _shakeEgg() {
+  async drawShakedEgg() {
     const standFrame = this.frameWidth * 2;
     let shakeCount = 3;
 
@@ -115,43 +96,35 @@ class Egg extends Animatable {
       shakeCount--;
 
       if (!shakeCount) {
-        clearTimeout(this.timer);
         resolve();
-
         return true;
       }
     }, SHAKED_TIME);
   }
 
-  _breakEgg(nextDraw) {
-    const lastFrame = 5;
+  async drawBreakingEgg() {
+    const lastFrame = 6;
     let currentFrame = 2;
 
-    return this.animate(
-      (resolve) => {
-        this.context.drawImage(
-          this.image,
-          this.frameWidth * currentFrame,
-          0,
-          200,
-          200,
-          this.dX,
-          this.dY,
-          200,
-          200,
-        );
-        currentFrame++;
+    return this.animate((resolve) => {
+      this.context.drawImage(
+        this.image,
+        this.frameWidth * currentFrame,
+        0,
+        200,
+        200,
+        this.dX,
+        this.dY,
+        200,
+        200,
+      );
+      currentFrame++;
 
-        if (lastFrame === currentFrame) {
-          clearTimeout(this.timer);
-          resolve();
-
-          return true;
-        }
-      },
-      BREAKUP_TIME,
-      nextDraw,
-    );
+      if (lastFrame === currentFrame) {
+        resolve();
+        return true;
+      }
+    }, BREAKUP_TIME);
   }
 }
 

--- a/views/Frame.js
+++ b/views/Frame.js
@@ -3,6 +3,11 @@ class Frame {
     this.context = document.querySelector('#frame').getContext('2d');
   }
 
+  draw() {
+    this._drawTamagotchiEgg();
+    this._drawTamagotchiBackground();
+  }
+
   _drawTamagotchiEgg() {
     const context = this.context;
 
@@ -39,11 +44,6 @@ class Frame {
     context.lineTo(215, 270);
     context.lineTo(230, 230);
     context.fill();
-  }
-
-  draw() {
-    this._drawTamagotchiEgg();
-    this._drawTamagotchiBackground();
   }
 }
 

--- a/views/Menu.js
+++ b/views/Menu.js
@@ -1,0 +1,38 @@
+class Menu {
+  constructor() {
+    this.menu = document.querySelector('.menu');
+    this.items = this.menu.querySelectorAll('.menu-item');
+    this.currentItemIndex = 0;
+
+    this.handleMenu = this.handleMenu.bind(this);
+    this.cancelMenu = this.cancelMenu.bind(this);
+  }
+
+  _openMenu() {
+    this.menu.classList.remove('hidden');
+    this.items[this.currentItemIndex].classList.add('focused');
+  }
+
+  _changeMenu() {
+    this.items[this.currentItemIndex].classList.remove('focused');
+    this.currentItemIndex = (this.currentItemIndex + 1) % this.items.length;
+    this.items[this.currentItemIndex].classList.add('focused');
+  }
+
+  handleMenu() {
+    if (this.menu.classList.contains('hidden')) {
+      this._openMenu();
+      return;
+    }
+
+    this._changeMenu();
+  }
+
+  cancelMenu() {
+    this.items[this.currentItemIndex].classList.remove('focused');
+    this.currentItemIndex = 0;
+    this.menu.classList.add('hidden');
+  }
+}
+
+export default new Menu();

--- a/views/Modal.js
+++ b/views/Modal.js
@@ -1,0 +1,15 @@
+class Modal {
+  constructor() {
+    this.modal = document.querySelector('.modal');
+  }
+
+  openModal() {
+    this.modal.classList.remove('hidden');
+  }
+
+  hiddenModal() {
+    this.modal.classList.add('hidden');
+  }
+}
+
+export default new Modal();


### PR DESCRIPTION
## 개요
- 펫의 상태가 child일때부터는 왼쪽 버튼이 메뉴 컨트롤 버튼, 오른쪽 버튼이 메뉴 취소 버튼으로 변경됨
- 메뉴가 켜져있을때는 시간의 흐름에 따른 상태값 변화가 발생하지 않음.
- 기존의 애니메이션 순서 설정에 nextAnimation이라는 콜백함수에 의존하는 방법이 비효율적이라고 여겨서, 애니메이션의 순서를 드로잉 함수들을 Promisify하게 변경하고 async-await로 처리해서 강제하도록 설정
- 컨트롤러에서 함수 바인딩이 자주 발생하는 것 같아서 api들을 전부 this 바인딩해서 보내는 것으로 처리


## PR Type

- [x] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [x] 기능 구현

- [x] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

- index.html에 메뉴를 추가함. 기본값은 hidden

```html
  <body>
    <div class="tamagotchi-container">
      <canvas id="frame" width="900" height="900"></canvas>
      <canvas id="tablet" width="400" height="400"></canvas>
      <div class="btns">
        <button class="btn btn--1"></button>
        <button class="btn btn--2"></button>
        <button class="btn btn--3"></button>
      </div>
      <div class="modal"><span>Press Any Button!</span></div>
      <div class="menu hidden">
        <div class="menu-item">FEED</div>
        <div class="menu-item">PLAY</div>
        <div class="menu-item">STATE</div>
        <div class="menu-item">SLEEP</div>
      </div>
    </div>
  </body>
```

- Menu 클래스를 만들어서 메뉴 on/off를 컨트롤함. css class로 컨트롤.
- 왼쪽 버튼을 클릭시 메뉴가 꺼져 있으면 메뉴창을 열고, 메뉴가 켜져있으면 메뉴 내부의 아이템들의 포커스를 변경하는 구조. 
- currentItemIndex번째 아이템에 포커스가 되있다.

```js
//Menu.js
  _changeMenu() {
    this.items[this.currentItemIndex].classList.remove('focused');
    this.currentItemIndex = (this.currentItemIndex + 1) % this.items.length;
    this.items[this.currentItemIndex].classList.add('focused');
  }

  handleMenu() {
    if (this.menu.classList.contains('hidden')) {
      this._openMenu();
      return;
    }

    this._changeMenu();
  }
```

- 오른쪽 버튼을 누르면 메뉴가 사라진다

```js
//Menu.js
 cancelMenu() {
    this.items[this.currentItemIndex].classList.remove('focused');
    this.currentItemIndex = 0;
    this.menu.classList.add('hidden');
  }
```

- menu를 관리하는 것도 각각의 view에서 맡아야 할 것이라고 생각되어, menu 인스턴스를 child 클래스에 넣은 다음, child 내부에서 menu 메소드들을 활용하도록 설정함

```js
//Child.js
import Animatable from './Animatable.js';
import menu from './Menu.js';

//...

class Child extends Animatable {
  constructor() {
    super();
    this.dX = 55;
    this.dY = 55;
    this.frameWidth = 300;
    this.menu = menu;
  }

  //...

  drawMenu(setMenuState) {
    this.clear();
    this.cancelAnimation(true);
    this.menu.handleMenu();
    setMenuState();
  }

  removeMenu(removeMenuState) {
    this.cancelAnimation(false);
    removeMenuState();
    this.menu.cancelMenu();
    this.drawIdlingChild();
  }

  //...
}
```

- 메뉴를 킬 경우 this.isCanceled가 되서 기존의 애니메이션 프라미스를 중단하고 메뉴창이 켜진다.
- 메뉴를 끌경우 this.isCanceled를 cancelAnimation을 사용해서 false로 만들어서 애니메이션이 계속되도록 한다.

```js
class Animatable {
  constructor() {
    this.context = document.querySelector('#tablet').getContext('2d');
    this.isCanceled = false;
    this.timer = null;
    this.image = new Image();
    this.pending = [];
  }

  animate(draw, ms) {
    return new Promise((resolve) => {
      const animation = async () => {
        this.clear();
        if (this.isCanceled) return;

        const isComplete = draw(resolve);

        if (!isComplete) {
          await this.delay(ms);
          animation();
        }
      };

      animation();
    });
  }

  cancelAnimation(isCanceled) {
    this.isCanceled = isCanceled;
  }
```

- 결과

![Recording 2022-07-03 at 23 06 51](https://user-images.githubusercontent.com/92532339/177043455-035e4203-a915-410a-a94e-2305228907c5.gif)


## 자가 체크리스트

- [x] PR 이전에 코드를 자가점검 했습니다.

- [ ] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 현 시점까지 상황 요약
- 메뉴를 선택 시 애니메이션을 발동하는 로직 구현 필요.
- PR단위가 너무 큰 것 같음. 큰 로직이 변경되면 바로바로 PR하기.
