### PR TITLE
프로필 공유 방에서 실제 데이터 표현

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -6,6 +6,7 @@ import ChildView from '../views/ChildView.js';
 import StateView from '../views/StateView.js';
 import MainModalView from '../views/MainModalView.js';
 import ProfileModalView from '../views/ProfileModalView.js';
+import ProfileRoomView from '../views/ProfileRoomView.js';
 import FrameView from '../views/FrameView.js';
 import MenuView from '../views/MenuView.js';
 import Router from '../routes/Router.js';
@@ -29,6 +30,7 @@ import {
 import mainStyles from '../css/main.css';
 import navbarStyles from '../css/navbar.css';
 import profileStyles from '../css/profile.css';
+import profileRoomStyles from '../css/profile-room.css';
 
 class Controller {
   constructor() {
@@ -42,6 +44,7 @@ class Controller {
     this.stateView = new StateView();
     this.mainModalView = new MainModalView();
     this.profileModalView = new ProfileModalView();
+    this.profileRoomView = new ProfileRoomView();
     this.menuView = new MenuView();
     this.currentMainView = null;
 
@@ -269,6 +272,18 @@ class Controller {
 
         this.profileModalView.closeUpdateModal();
       });
+  }
+
+  async handleSettingProfileRoomPage() {
+    const roomLeft = document.querySelector(
+      `.${profileRoomStyles['room-left']}`,
+    );
+
+    this.profileRoomView.setProfileRoomElements(roomLeft);
+    this.profileRoomView.drawProfileRoom(
+      this.userState.picture,
+      this.gameState,
+    );
   }
 
   async handlePatchingProfileInfo(newProfile) {

--- a/init.js
+++ b/init.js
@@ -26,6 +26,10 @@ async function init() {
     controller.handleSettingNavBar();
     controller.handleSettingProfilePage();
     controller.handleEventsOverTime();
+  } else if (controller.router.currentRoute === '/profile/:userId') {
+    await controller.handleGettingUserInfo();
+    controller.router.navigateTo('/');
+    return;
   } else if (controller.router.currentRoute === '/login') {
     document
       .querySelector('button')

--- a/routes/ProfileRoomPage.js
+++ b/routes/ProfileRoomPage.js
@@ -2,10 +2,7 @@ import Page from './Page.js';
 import profileRoomStyles from '../css/profile-room.css';
 import navbarStyles from '../css/navbar.css';
 
-import {
-  CHILD_STAND_IMAGE_PATH,
-  LOGO_IMAGE_PATH,
-} from '../constants/imagePath.js';
+import { LOGO_IMAGE_PATH } from '../constants/imagePath.js';
 
 class ProfileRoomPage extends Page {
   constructor(params) {
@@ -28,16 +25,10 @@ class ProfileRoomPage extends Page {
         <div class="${profileRoomStyles['room-container']}">
           <div class="${profileRoomStyles['room-left']}">
             <div class="${profileRoomStyles['host-info']}">
-              <img src="https://lh3.googleusercontent.com/a/AItbvmktChZQniyEYfd_RWGfoHMtzKHvCUQLWmcGKftP=s96-c" alt="user profile picture" />
               <h1>${this.userId}</h1>
             </div>
             <div class="${profileRoomStyles['host-pet-card']}">
-              <img src=".${CHILD_STAND_IMAGE_PATH}" alt="pet stand" />
-              <div class="${profileRoomStyles['host-pet-profile']}">
-                <span>Name: yoobin</span>
-                <span>Description: hi</span>
-                <span>Happiness: 20</span>
-              </div>
+              <div class="${profileRoomStyles['host-pet-profile']}"></div>
             </div>
           </div>
           <div class="${profileRoomStyles['room-right']}">

--- a/routes/Router.js
+++ b/routes/Router.js
@@ -74,6 +74,7 @@ class Router {
     }
 
     this.currentRoute = match.route.path;
+    console.log(this.currentRoute);
 
     const view = new match.route.view(this.getParams(match));
     const root = document.querySelector('#root');

--- a/utils/observer.js
+++ b/utils/observer.js
@@ -25,6 +25,9 @@ export function observeRoot(controller) {
     } else if (controller.router.currentRoute === '/profile') {
       controller.handleSettingNavBar();
       controller.handleSettingProfilePage();
+    } else if (controller.router.currentRoute === '/profile/:userId') {
+      controller.handleSettingNavBar();
+      controller.handleSettingProfileRoomPage();
     } else if (controller.router.currentRoute === '/login') {
       document
         .querySelector('button')

--- a/views/ProfileRoomView.js
+++ b/views/ProfileRoomView.js
@@ -1,0 +1,66 @@
+import profileRoomStyles from '../css/profile-room.css';
+import { GROWTH } from '../constants/gameState.js';
+import {
+  EGG_IMAGE_PATH,
+  CHILD_STAND_IMAGE_PATH,
+  ADULT_STAND_IMAGE_PATH,
+} from '../constants/imagePath.js';
+
+class ProfileRoomView {
+  #roomLeft = null;
+  #hostInfo = null;
+  #hostPetProfile = null;
+  #hostPetCard = null;
+
+  constructor() {}
+
+  setProfileRoomElements(roomLeft) {
+    this.#roomLeft = roomLeft;
+    this.#hostInfo = this.#roomLeft.querySelector(
+      `.${profileRoomStyles['host-info']}`,
+    );
+    this.#hostPetCard = this.#roomLeft.querySelector(
+      `.${profileRoomStyles['host-pet-card']}`,
+    );
+    this.#hostPetProfile = this.#roomLeft.querySelector(
+      `.${profileRoomStyles['host-pet-profile']}`,
+    );
+  }
+
+  drawProfileRoom(profileImage, gameState) {
+    console.log(gameState.growth);
+
+    if (gameState.growth === GROWTH[0]) {
+      this.#hostPetCard.insertAdjacentHTML(
+        'afterbegin',
+        `<img src=".${EGG_IMAGE_PATH}" alt="egg stand" />`,
+      );
+    } else if (gameState.growth === GROWTH[1]) {
+      this.#hostPetCard.insertAdjacentHTML(
+        'afterbegin',
+        `<img src=".${CHILD_STAND_IMAGE_PATH}" alt="child stand" />`,
+      );
+    } else if (gameState.growth === GROWTH[2]) {
+      this.#hostPetCard.insertAdjacentHTML(
+        'afterbegin',
+        `<img src=".${ADULT_STAND_IMAGE_PATH}" alt="adult stand" />`,
+      );
+    }
+
+    this.#hostInfo.insertAdjacentHTML(
+      'afterbegin',
+      `<img src="${profileImage}" alt="profile" />`,
+    );
+
+    this.#hostPetProfile.insertAdjacentHTML(
+      'afterbegin',
+      `
+        <span>Name: ${gameState.profileName}</span>
+        <span>Description: ${gameState.profileDescription}</span>
+        <span>Happiness: ${gameState.happiness}</span>
+      `,
+    );
+  }
+}
+
+export default ProfileRoomView;


### PR DESCRIPTION
## 개요
- 현재 내 펫의 상태를 기반으로 프로필 공유 방이 출력되도록 설정
- 임시로 url을 직접 쳐서 /profile/:userId로 들어가거나 새로고침하면 메인페이지로 돌아오도록 설정함.

## PR Type

- [ ] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [x] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

- 변경된 코드에서 가장 핵심이 되는 부분을 설명. 필요할 경우 이미지 파일이나 코드를 첨부

```js
  async handleSettingProfileRoomPage() {
    const roomLeft = document.querySelector(
      `.${profileRoomStyles['room-left']}`,
    );

    this.profileRoomView.setProfileRoomElements(roomLeft);
    this.profileRoomView.drawProfileRoom(
      this.userState.picture,
      this.gameState,
    );
  }
```

## 자가 체크리스트

- [x] PR 이전에 코드를 자가점검 했습니다.

- [ ] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 현 시점까지 상황 요약 + 추가로 해야 할 일
- profile 페이지에 들어갈 때 현재 열려있는 room의 갯수가 몇개인지 체크하고 불러오는 로직 필요
- 해당 id와 일치하는 room이 열려있으면 따라서 /profile/:userId 입력시 접속 가능, 아니면 /profile로 리다이렉트
