### PR TITLE
로그아웃 버그 픽스

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -202,6 +202,7 @@ class Controller {
 
   handleSettingNavBar() {
     const logoutLink = document.querySelector(`.${navbarStyles.logout}`);
+
     logoutLink.addEventListener('click', () => {
       localStorage.removeItem('isLoggedIn');
       this.handleUserLogout();

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -132,7 +132,7 @@ class Controller {
   }
 
   async handleUserLogout() {
-    // await this.handlePatchingUserInfo();
+    await this.handlePatchingUserInfo();
     this.gameState.reset();
     this.buttonState.reset();
     logout();
@@ -202,7 +202,10 @@ class Controller {
 
   handleSettingNavBar() {
     const logoutLink = document.querySelector(`.${navbarStyles.logout}`);
-    logoutLink.addEventListener('click', this.handleUserLogout.bind(this));
+    logoutLink.addEventListener('click', () => {
+      localStorage.removeItem('isLoggedIn');
+      this.handleUserLogout();
+    });
   }
 
   async handleSettingProfilePage() {

--- a/init.js
+++ b/init.js
@@ -1,6 +1,6 @@
 import Controller from './controllers/index.js';
 import { observeRoot } from './utils/observer.js';
-import { postUserInfoWithClose } from './utils/api.js';
+import { postUserInfoWithClose, logout } from './utils/api.js';
 
 async function init() {
   const isLoggedIn = localStorage.getItem('isLoggedIn') === 'true';
@@ -16,6 +16,8 @@ async function init() {
     };
 
     postUserInfoWithClose(userInformation);
+    localStorage.removeItem('isLoggedIn');
+    logout();
   });
 
   if (controller.router.currentRoute === '/') {

--- a/init.js
+++ b/init.js
@@ -1,6 +1,7 @@
 import Controller from './controllers/index.js';
 import { observeRoot } from './utils/observer.js';
-import { postUserInfoWithClose, logout } from './utils/api.js';
+import { postUserInfoWithClose } from './utils/api.js';
+import { signOut } from 'firebase/auth';
 
 async function init() {
   const isLoggedIn = localStorage.getItem('isLoggedIn') === 'true';
@@ -16,8 +17,9 @@ async function init() {
     };
 
     postUserInfoWithClose(userInformation);
+
     localStorage.removeItem('isLoggedIn');
-    logout();
+    signOut();
   });
 
   if (controller.router.currentRoute === '/') {

--- a/utils/api.js
+++ b/utils/api.js
@@ -12,7 +12,6 @@ async function getToken() {
 }
 
 export function logout() {
-  localStorage.removeItem('isLoggedIn');
   document.cookie = `server_token=''; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
   auth.signOut();
 }

--- a/utils/observer.js
+++ b/utils/observer.js
@@ -3,12 +3,14 @@ import loginStyles from '../css/login.css';
 
 export function observeRoot(controller) {
   const observer = new MutationObserver(async (entries) => {
-    const debouncedPatching = debounce(
-      controller.handlePatchingUserInfo.bind(controller),
-      3000,
-    );
+    if (controller.router.currentRoute !== '/login') {
+      const debouncedPatching = debounce(
+        controller.handlePatchingUserInfo.bind(controller),
+        3000,
+      );
 
-    debouncedPatching();
+      debouncedPatching();
+    }
 
     if (controller.router.currentRoute === '/') {
       controller.handleSettingMainPage();


### PR DESCRIPTION
## 개요
- 로그아웃 링크 클릭 시 데이터를 저장하지 않고 에러가 발생되던 버그 픽스

## PR Type

- [x] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [ ] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

- 기존 코드의 문제는 로컬 스토리지를 제거하지 않고 /login으로 들어가면 자동으로 /로 리다이렉팅 되는데서 발생. 매번 새로운 렌더링 마다메인 메뉴 관런 div를 새로 잡아줘야 하는데 그게 생략되면서 에러 발생. 이후 코드도 동작하지 않음.
- 그래서 로컬스토리지를 삭제한 다음 로그아웃 로직이 진행되도록 변경함

```js
 handleSettingNavBar() {
    const logoutLink = document.querySelector(`.${navbarStyles.logout}`);

    logoutLink.addEventListener('click', () => {
      localStorage.removeItem('isLoggedIn');
      this.handleUserLogout();
    });
  }
```

## 자가 체크리스트

- [x] PR 이전에 코드를 자가점검 했습니다.

- [ ] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 현 시점까지 상황 요약 + 추가로 해야 할 일
- 컨트롤러 클래스 분리하기
- 다마고치 기분 화면에 드로잉하는 기능 추가