### PR TITLE
시작 모드/ 알 모드일 때 프로필 페이지 접속 막음

### DIFF
--- a/init.js
+++ b/init.js
@@ -1,6 +1,7 @@
 import Controller from './src/controller/Controller.js';
 import { observeRoot } from './src/utils/observer.js';
 import { postUserInfoWithClose } from './src/utils/api.js';
+import { GROWTH } from './src/constants/gameState.js';
 
 async function init() {
   const isLoggedIn = localStorage.getItem('isLoggedIn') === 'true';
@@ -19,6 +20,10 @@ async function init() {
   });
 
   if (controller.router.currentRoute === '/') {
+    if (controller.currentAnimationFrame) {
+      cancelAnimationFrame(controller.currentAnimationFrame);
+    }
+
     await controller.handleGettingUserInfo();
 
     if (isLoggedIn) {
@@ -28,6 +33,14 @@ async function init() {
       controller.handleEventsOverTime();
     }
   } else if (controller.router.currentRoute === '/profile') {
+    if (
+      controller.gameState.growth !== GROWTH[1] &&
+      controller.gameState.growth !== GROWTH[2]
+    ) {
+      controller.router.navigateTo('/');
+      return;
+    }
+
     await controller.handleGettingUserInfo();
 
     if (isLoggedIn) {

--- a/init.js
+++ b/init.js
@@ -20,11 +20,11 @@ async function init() {
   });
 
   if (controller.router.currentRoute === '/') {
+    await controller.handleGettingUserInfo();
+
     if (controller.currentAnimationFrame) {
       cancelAnimationFrame(controller.currentAnimationFrame);
     }
-
-    await controller.handleGettingUserInfo();
 
     if (isLoggedIn) {
       controller.handleSettingNavBar();

--- a/src/controller/Controller.js
+++ b/src/controller/Controller.js
@@ -10,6 +10,7 @@ import ProfileView from '../views/ProfileView.js';
 import FrameView from '../views/FrameView.js';
 import MenuView from '../views/MenuView.js';
 import MoodView from '../views/MoodView.js';
+import NavbarView from '../views/NavbarView.js';
 import Router from './Router.js';
 
 import { INIT, GROWTH, TICK_SECONDS, IDLING } from '../constants/gameState.js';
@@ -50,7 +51,9 @@ class Controller {
     this.profileView = new ProfileView();
     this.menuView = new MenuView();
     this.moodView = new MoodView();
+    this.navbarView = new NavbarView();
     this.currentMainView = null;
+    this.currentAnimationFrame = null;
 
     this.router.init();
   }
@@ -97,7 +100,7 @@ class Controller {
         nextTimeforEvent = currentTime + TICK_SECONDS;
       }
 
-      requestAnimationFrame(handleEventsOnTick);
+      this.currentAnimationFrame = requestAnimationFrame(handleEventsOnTick);
     };
 
     handleEventsOnTick();
@@ -196,6 +199,7 @@ class Controller {
     const frame = document.querySelector(`#${mainStyles.frame}`);
     const tablet = document.querySelector(`#${mainStyles.tablet}`);
     const modal = document.querySelector(`.${mainStyles.modal}`);
+    const navbar = document.querySelector('nav');
 
     this.buttonState.setButtonElements(leftBtn, middleBtn, rightBtn);
     this.frameView.setContext(frame);
@@ -206,6 +210,7 @@ class Controller {
     this.moodView.setContainer(tamagotchiContainer);
     this.stateView.setContext(tablet);
     this.mainModalView.setModalElement(modal);
+    this.navbarView.setNavbar(navbar);
 
     this.frameView.draw();
     this.#handleChangingPetPhases();
@@ -444,6 +449,8 @@ class Controller {
 
     this.currentMainView = this.childView;
 
+    this.navbarView.showProfileLink();
+
     if (this.router.currentRoute === '/') {
       this.mainModalView.hiddenModal();
     }
@@ -500,6 +507,7 @@ class Controller {
     }
 
     this.currentMainView = this.adultView;
+    this.navbarView.showProfileLink();
 
     if (this.router.currentRoute === '/') {
       this.mainModalView.hiddenModal();

--- a/src/css/navbar.css
+++ b/src/css/navbar.css
@@ -34,3 +34,7 @@ nav a {
 .logout {
   display: block;
 }
+
+.hidden {
+  display: none;
+}

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -17,7 +17,7 @@ class MainPage extends Page {
           <img src="${LOGO_IMAGE_PATH}" alt="logo" />
           <div class="${navbarStyles['navbar-links']}">
             <a href="/" data-link>main</a>
-            <a href="/profile" data-link>profile</a>
+            <a href="/profile" class="${navbarStyles.hidden}" data-link>profile</a>
             <a href="/" class="${navbarStyles.logout}" data-link>logout</a>
           </div>
         </nav>

--- a/src/utils/observer.js
+++ b/src/utils/observer.js
@@ -1,9 +1,11 @@
 import debounce from 'lodash.debounce';
 import loginStyles from '../css/login.css';
+import profileStyles from '../css/profile.css';
+import { GROWTH } from '../constants/gameState';
 
 export function observeRoot(controller) {
   const observer = new MutationObserver(async (entries) => {
-    if (controller.router.currentRoute !== '/login') {
+    if (location.pathname === '/' || location.pathname === '/profile') {
       const debouncedPatching = debounce(
         controller.handlePatchingUserInfo.bind(controller),
         3000,
@@ -13,19 +15,40 @@ export function observeRoot(controller) {
     }
 
     if (controller.router.currentRoute === '/') {
+      const fromLoginPage = entries[0].removedNodes[1].classList.contains(
+        loginStyles.container,
+      );
+
+      const fromProfileBeforeEgg =
+        entries[0].removedNodes[1].classList.contains(
+          profileStyles.container,
+        ) &&
+        controller.gameState.growth !== GROWTH[1] &&
+        controller.gameState.growth !== GROWTH[2];
+
       controller.handleSettingMainPage();
       controller.handleSettingNavBar();
       controller.handleMoodImage();
 
-      if (
-        entries[0].removedNodes[1].classList.contains(loginStyles.container)
-      ) {
+      if (fromLoginPage || fromProfileBeforeEgg) {
+        if (controller.currentAnimationFrame) {
+          cancelAnimationFrame(controller.currentAnimationFrame);
+        }
+
         controller.gameState.setIdlingState();
         controller.handleEventsOverTime();
       }
     } else if (controller.router.currentRoute === '/profile') {
       controller.handleSettingNavBar();
       controller.handleSettingProfilePage();
+
+      if (
+        controller.gameState.growth !== GROWTH[1] &&
+        controller.gameState.growth !== GROWTH[2]
+      ) {
+        controller.router.navigateTo('/');
+        controller.handleEventsOverTime();
+      }
     } else if (controller.router.currentRoute === '/login') {
       document
         .querySelector('button')

--- a/src/utils/observer.js
+++ b/src/utils/observer.js
@@ -1,10 +1,9 @@
 import debounce from 'lodash.debounce';
-import loginStyles from '../css/login.css';
-import profileStyles from '../css/profile.css';
+
 import { GROWTH } from '../constants/gameState';
 
 export function observeRoot(controller) {
-  const observer = new MutationObserver(async (entries) => {
+  const observer = new MutationObserver(async () => {
     if (location.pathname === '/' || location.pathname === '/profile') {
       const debouncedPatching = debounce(
         controller.handlePatchingUserInfo.bind(controller),
@@ -15,29 +14,15 @@ export function observeRoot(controller) {
     }
 
     if (controller.router.currentRoute === '/') {
-      const fromLoginPage = entries[0].removedNodes[1].classList.contains(
-        loginStyles.container,
-      );
-
-      const fromProfileBeforeEgg =
-        entries[0].removedNodes[1].classList.contains(
-          profileStyles.container,
-        ) &&
-        controller.gameState.growth !== GROWTH[1] &&
-        controller.gameState.growth !== GROWTH[2];
+      if (controller.currentAnimationFrame) {
+        cancelAnimationFrame(controller.currentAnimationFrame);
+      }
 
       controller.handleSettingMainPage();
       controller.handleSettingNavBar();
       controller.handleMoodImage();
-
-      if (fromLoginPage || fromProfileBeforeEgg) {
-        if (controller.currentAnimationFrame) {
-          cancelAnimationFrame(controller.currentAnimationFrame);
-        }
-
-        controller.gameState.setIdlingState();
-        controller.handleEventsOverTime();
-      }
+      controller.gameState.setIdlingState();
+      controller.handleEventsOverTime();
     } else if (controller.router.currentRoute === '/profile') {
       controller.handleSettingNavBar();
       controller.handleSettingProfilePage();

--- a/src/views/NavbarView.js
+++ b/src/views/NavbarView.js
@@ -1,0 +1,23 @@
+import navbarStyles from '../css/navbar.css';
+
+class NavbarView {
+  #navbar = null;
+
+  setNavbar(navbar) {
+    this.#navbar = navbar;
+  }
+
+  showProfileLink() {
+    this.#navbar
+      .querySelector("a[href='/profile']")
+      .classList.remove(`${navbarStyles.hidden}`);
+  }
+
+  hideProfileLink() {
+    this.#navbar
+      .querySelector("a[href='/profile']")
+      .classList.add(`${navbarStyles.hidden}`);
+  }
+}
+
+export default NavbarView;


### PR DESCRIPTION
## 개요
- 시작이나 알 상태일때는 navbar에 프로필 링크가 뜨지 않으며, 로그인한 상태에서 /profile로 접속해도 /으로 리다이렉트됨
- /로 접속시 requestAnimationFrame이 있다면 캔슬하고 다시 requestAnimationFrame을 시작하도록 설정함.

## PR Type

- [ ] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [x] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

- NavbarView를 설정해서 성장 수치에 따라 navbar의 hidden 클래스를 조정함.

```js
class NavbarView {
  #navbar = null;

  setNavbar(navbar) {
    this.#navbar = navbar;
  }

  showProfileLink() {
    this.#navbar
      .querySelector("a[href='/profile']")
      .classList.remove(`${navbarStyles.hidden}`);
  }

  hideProfileLink() {
    this.#navbar
      .querySelector("a[href='/profile']")
      .classList.add(`${navbarStyles.hidden}`);
  }
}
```

## 자가 체크리스트

- [x] PR 이전에 코드를 자가점검 했습니다.

- [ ] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 현 시점까지 상황 요약 + 추가로 해야 할 일
- 버튼에 사운드 추가
- 테스트 코드 작성
