### PR TITLE
강제수면 이후 사운드 없어지는 버그 픽스

### DIFF
--- a/src/controllers/Controller.js
+++ b/src/controllers/Controller.js
@@ -319,6 +319,7 @@ class Controller {
       this.menuView.drawMenu();
       this.gameState.setMenuState();
       this.moodView.clearMoodImage();
+      this.audioController.playSelectMenuSound();
     };
 
     const middleCallback = () => {
@@ -339,6 +340,7 @@ class Controller {
 
       this.childView.drawIdlingChild();
       this.handleMoodImage();
+      this.audioController.playCancelMenuSound();
     };
 
     this.audioController.playSleepSound();
@@ -361,6 +363,7 @@ class Controller {
       this.menuView.drawMenu();
       this.gameState.setMenuState();
       this.moodView.clearMoodImage();
+      this.audioController.playSelectMenuSound();
     };
 
     const middleCallback = () => {
@@ -381,6 +384,7 @@ class Controller {
 
       this.adultView.drawIdlingAdult();
       this.handleMoodImage();
+      this.audioController.playCancelMenuSound();
     };
 
     this.audioController.playSleepSound();


### PR DESCRIPTION
## 개요
- 강제 수면 이후 버튼 사운드가 사라지는 버그를 픽스함

## PR Type

- [x] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [ ] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

- 리스너를 다시 달 때 사운드 메소드를 달지 않은 문제여서 달아주는 것으로 수정이 됨

## 자가 체크리스트

- [x] PR 이전에 코드를 자가점검 했습니다.

- [ ] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 현 시점까지 상황 요약 + 추가로 해야 할 일
- 리드미 시작
