### PR TITLE
helpmodal과 로그아웃 버튼 이벤트 리스너 설정, 

### DIFF
--- a/src/controllers/Controller.js
+++ b/src/controllers/Controller.js
@@ -32,7 +32,6 @@ import {
 } from '../utils/api.js';
 
 import mainStyles from '../css/main.css';
-import navbarStyles from '../css/navbar.css';
 import profileStyles from '../css/profile.css';
 
 class Controller {
@@ -230,9 +229,7 @@ class Controller {
   }
 
   handleSettingNavBar() {
-    const logoutLink = document.querySelector(`.${navbarStyles.logout}`);
-
-    logoutLink.addEventListener('click', () => {
+    this.navbarView.addLogoutListener(() => {
       localStorage.removeItem('isLoggedIn');
       this.handleUserLogout();
     });

--- a/src/controllers/Controller.js
+++ b/src/controllers/Controller.js
@@ -226,9 +226,7 @@ class Controller {
       xBtn,
     );
 
-    [xBtn, backdrop, helpModalBtn].forEach((element) => {
-      element.addEventListener('click', this.helpModalView.toggleHelpModal);
-    });
+    this.helpModalView.addListeners();
   }
 
   handleSettingNavBar() {

--- a/src/views/HelpModalView.js
+++ b/src/views/HelpModalView.js
@@ -7,7 +7,8 @@ class HelpModalView {
   #xBtn = null;
 
   constructor() {
-    this.toggleHelpModal = this.toggleHelpModal.bind(this);
+    this.setHelpModalElements = this.setHelpModalElements.bind(this);
+    this.showHelpModalBtn = this.showHelpModalBtn.bind(this);
   }
 
   setHelpModalElements(helpModal, backdrop, helpModalBtn, xBtn) {
@@ -17,11 +18,20 @@ class HelpModalView {
     this.#xBtn = xBtn;
   }
 
+  addListeners() {
+    this.#backdrop.addEventListener('click', this.#toggleHelpModal.bind(this));
+    this.#xBtn.addEventListener('click', this.#toggleHelpModal.bind(this));
+    this.#helpModalBtn.addEventListener(
+      'click',
+      this.#toggleHelpModal.bind(this),
+    );
+  }
+
   showHelpModalBtn() {
     this.#helpModalBtn.classList.remove(`${mainStyles.hidden}`);
   }
 
-  toggleHelpModal() {
+  #toggleHelpModal() {
     this.#backdrop.classList.toggle(`${mainStyles.hidden}`);
     this.#helpModal.classList.toggle(`${mainStyles.hidden}`);
   }

--- a/src/views/NavbarView.js
+++ b/src/views/NavbarView.js
@@ -2,14 +2,28 @@ import navbarStyles from '../css/navbar.css';
 
 class NavbarView {
   #navbar = null;
+  #logoutCallback = null;
 
   constructor() {
     this.setNavbar = this.setNavbar.bind(this);
     this.showProfileLink = this.showProfileLink.bind(this);
+    this.addLogoutListener = this.addLogoutListener.bind(this);
   }
 
   setNavbar(navbar) {
     this.#navbar = navbar;
+  }
+
+  addLogoutListener(callback) {
+    const logoutLink = document.querySelector(`.${navbarStyles.logout}`);
+
+    if (this.#logoutCallback) {
+      logoutLink.removeEventListener('click', this.#logoutCallback);
+    }
+
+    this.#logoutCallback = callback;
+
+    logoutLink.addEventListener('click', this.#logoutCallback);
   }
 
   showProfileLink() {


### PR DESCRIPTION
## 개요
- 컨트롤러에서 이벤트 리스너를 직접 다는 로직이 아니라 view에서 컨트롤러의 명령을 받아 이벤트리스너를 다는 것이 더 자연스럽다고 생각 되어서 로직을 변경함
- 다만, 프로필 업데이트 모달은 초기 코드가 꼬여서 해결하는데 시간이 걸릴 것으로 보임. 시간문제상 아직 변경하지 못했으나 시간이 나는대로 수정할 예정

## PR Type

- [x] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [ ] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

- view에 다음과 같은 식으로 코드를 입력해서 view의 메소드를 실행해서 리스너를 다는 것으로 변경

```js
  addLogoutListener(callback) {
    const logoutLink = document.querySelector(`.${navbarStyles.logout}`);

    if (this.#logoutCallback) {
      logoutLink.removeEventListener('click', this.#logoutCallback);
    }

    this.#logoutCallback = callback;

    logoutLink.addEventListener('click', this.#logoutCallback);
  }
```

## 자가 체크리스트

- [x] PR 이전에 코드를 자가점검 했습니다.

- [ ] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [ ] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [ ] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 현 시점까지 상황 요약 + 추가로 해야 할 일
- 프로필 페이지의 이벤트리스너 로직들도 뷰로 옮기는 변경 필요
