### PR TITLE
컨트롤러에서 이벤트리스너 콜백 설정

### DIFF
--- a/src/controllers/Controller.js
+++ b/src/controllers/Controller.js
@@ -225,7 +225,9 @@ class Controller {
       xBtn,
     );
 
-    this.helpModalView.addListeners();
+    this.helpModalView.addListeners(
+      this.helpModalView.toggleHelpmodal.bind(this),
+    );
   }
 
   handleSettingNavBar() {

--- a/src/controllers/Controller.js
+++ b/src/controllers/Controller.js
@@ -225,9 +225,7 @@ class Controller {
       xBtn,
     );
 
-    this.helpModalView.addListeners(
-      this.helpModalView.toggleHelpmodal.bind(this),
-    );
+    this.helpModalView.addListeners(() => this.helpModalView.toggleHelpModal());
   }
 
   handleSettingNavBar() {

--- a/src/views/HelpModalView.js
+++ b/src/views/HelpModalView.js
@@ -18,20 +18,17 @@ class HelpModalView {
     this.#xBtn = xBtn;
   }
 
-  addListeners() {
-    this.#backdrop.addEventListener('click', this.#toggleHelpModal.bind(this));
-    this.#xBtn.addEventListener('click', this.#toggleHelpModal.bind(this));
-    this.#helpModalBtn.addEventListener(
-      'click',
-      this.#toggleHelpModal.bind(this),
-    );
+  addListeners(callback) {
+    this.#backdrop.addEventListener('click', callback);
+    this.#xBtn.addEventListener('click', callback);
+    this.#helpModalBtn.addEventListener('click', callback);
   }
 
   showHelpModalBtn() {
     this.#helpModalBtn.classList.remove(`${mainStyles.hidden}`);
   }
 
-  #toggleHelpModal() {
+  toggleHelpModal() {
     this.#backdrop.classList.toggle(`${mainStyles.hidden}`);
     this.#helpModal.classList.toggle(`${mainStyles.hidden}`);
   }


### PR DESCRIPTION
## 개요
- 이벤트 리스너를 다는 콜백을 컨트롤러가 달아주는게 맞다고 생각해서 변경

## PR Type

- [x] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [ ] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

- view에서 콜백함수를 선택하는 것이 아닌 컨트롤러가 선택하도록 설정

```js
  addListeners(callback) {
    this.#backdrop.addEventListener('click', callback);
    this.#xBtn.addEventListener('click', callback);
    this.#helpModalBtn.addEventListener('click', callback);
  }
```

## 자가 체크리스트

- [x] PR 이전에 코드를 자가점검 했습니다.

- [ ] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 현 시점까지 상황 요약 + 추가로 해야 할 일